### PR TITLE
Rebrand to MooseSMP, Change token.json to config.json and include ctx.author in Verification Pending embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RLSMPVerify
+# MooseSMPVerify
 
 ## Setup
 

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ PROMPTS = (
     "Question 2",
 )
 # Make sure to change this in production.
-PROMPT_DESTINATION = 1115730155483185252
+PROMPT_DESTINATION = 1102847625813831680
 
 # The modal/form itself.
 class VerifyModal(miru.Modal):
@@ -32,7 +32,7 @@ class VerifyModal(miru.Modal):
     # This function is called when the user submit the form.
     async def callback(self, ctx: miru.ModalContext):
         # approvals
-        STAFF_REVIEW_CHANNEL_ID = 1115729185588129812
+        STAFF_REVIEW_CHANNEL_ID = 1102780545609515118
 
         embed = hikari.Embed(
             title = "Verification Pending",
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     
     @bot.command()
     # Check for Operators role.
-    @lightbulb.add_checks(lightbulb.has_roles(1115730276027482292))
+    @lightbulb.add_checks(lightbulb.has_roles(868609637778346024))
     @lightbulb.add_cooldown(length = 10.0, uses = 1, bucket = lightbulb.GlobalBucket)
     @lightbulb.command("send_prompt", "Send the prompt for verification. Only used once unless there are errors.")
     @lightbulb.implements(lightbulb.SlashCommand)

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ class VerifyModal(miru.Modal):
 
         embed = hikari.Embed(
             title = "Verification Pending",
-            description = f"Oncoming response from {ctx.author.mention}",
+            description = f"Oncoming response from {ctx.author.mention} ({ctx.author})",
             timestamp = dt.datetime.now().astimezone(),
         )
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-# This is a quick-and-dirty bot to solve an issue in RLSMP.
+# This is a quick-and-dirty bot to solve an issue in MooseSMP.
 # Therefore, the code practices/styles is going to be horrendous. Feel free to refactor it if you want to.
 
 # For Discord components: https://hikari-miru.readthedocs.io/en/latest/
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         msg = await ctx.bot.rest.create_message(
             PROMPT_DESTINATION, 
             dedent('''
-            Welcome to RLSMP! The Minecraft and Discord server are locked behind this gate to ensure a safe atmosphere. While it's a private server now, you can request access if you wish to chat or play.
+            Welcome to MooseSMP! The Minecraft and Discord server are locked behind this gate to ensure a safe atmosphere. While it's a private server now, you can request access if you wish to chat or play.
 
             1. Who invited you/How did you find out about this server? Why did you join it?
             2. What's your Java/Bedrock name? If you're just here to chill, answer so.

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ PROMPTS = (
     "Question 2",
 )
 # Make sure to change this in production.
-PROMPT_DESTINATION = 1102847625813831680
+PROMPT_DESTINATION = 1115730155483185252
 
 # The modal/form itself.
 class VerifyModal(miru.Modal):
@@ -32,7 +32,7 @@ class VerifyModal(miru.Modal):
     # This function is called when the user submit the form.
     async def callback(self, ctx: miru.ModalContext):
         # approvals
-        STAFF_REVIEW_CHANNEL_ID = 1102780545609515118
+        STAFF_REVIEW_CHANNEL_ID = 1115729185588129812
 
         embed = hikari.Embed(
             title = "Verification Pending",
@@ -69,7 +69,7 @@ class ModalTrigger(miru.View):
         await ctx.respond_with_modal(modal)
 
 if __name__ == "__main__":
-    with open("./setup/token.json") as fin:
+    with open("./setup/config.json") as fin:
         data = json.load(fin)
         token = data["token"]
         persisting_msg = data["target_msg"]
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     
     @bot.command()
     # Check for Operators role.
-    @lightbulb.add_checks(lightbulb.has_roles(868609637778346024))
+    @lightbulb.add_checks(lightbulb.has_roles(1115730276027482292))
     @lightbulb.add_cooldown(length = 10.0, uses = 1, bucket = lightbulb.GlobalBucket)
     @lightbulb.command("send_prompt", "Send the prompt for verification. Only used once unless there are errors.")
     @lightbulb.implements(lightbulb.SlashCommand)
@@ -133,7 +133,7 @@ if __name__ == "__main__":
         ctx.bot.d.msg_id = msg.id
 
         # No I don't care if it's going to corrupt the json, it's a small bot.
-        with open("./setup/token.json", mode = "w") as fout:
+        with open("./setup/config.json", mode = "w") as fout:
             data = {}
             data["token"] = ctx.bot._token
             data["target_msg"] = msg.id

--- a/setup/README.md
+++ b/setup/README.md
@@ -9,4 +9,4 @@ Create a `config.json` in this directory (setup) with the following format:
 }
 ```
 
-`"token"` is your bot token (don't leak). For `"target_msg"`, just target a random message's **ID** or the one in the gate channel.
+`"token"` is your bot token (don't leak). For `"target_msg"`, just target a random message's **ID** (this will result in an error the first time, but the second time it'll correct itself to the proper ID) or the one in the gate channel.

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,6 +1,6 @@
 # Setup
 
-Create a `token.json` in this directory (setup) with the following format:
+Create a `config.json` in this directory (setup) with the following format:
 
 ```json
 {

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,11 +1,11 @@
 # Setup
 
-Create a `token.json` with the following format:
+Create a `token.json` in this directory (setup) with the following format:
 
 ```json
 {
     "token": "bot token",
-    "target_msg": "msg id"
+    "target_msg": "1115732369148739674"
 }
 ```
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -4,8 +4,8 @@ Create a `token.json` in this directory (setup) with the following format:
 
 ```json
 {
-    "token": "ODQ0MTE3NjU3OTI5MTIxODAy.YKNv1A.2dIjSO7VF5x4_dv45A1LtXI3OvY",
-    "target_msg": "1115732369148739674"
+    "token": "token here",
+    "target_msg": "id here"
 }
 ```
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -4,7 +4,7 @@ Create a `token.json` in this directory (setup) with the following format:
 
 ```json
 {
-    "token": "bot token",
+    "token": "ODQ0MTE3NjU3OTI5MTIxODAy.YKNv1A.2dIjSO7VF5x4_dv45A1LtXI3OvY",
     "target_msg": "1115732369148739674"
 }
 ```


### PR DESCRIPTION
(Hopefully) all instances of RLSMP were turned into MooseSMP out of box now. 

token.json was changed into config.json due to it not being just for token (ok that may be the only real use) but accessing message id's from a token.json file seemed a bit weird.

Lastly, added ctx.author in brackets in the verification embed. This is due to the mentions sometimes bugging out and not showing the names properly. This is a "to be safe" feature.

Last but not least some minor readme updates.
IDs should be back to the original ones we use for the server.